### PR TITLE
fix: connect NotificationService to BatteryService

### DIFF
--- a/MagicMouseBattery/App/MagicMouseBatteryApp.swift
+++ b/MagicMouseBattery/App/MagicMouseBatteryApp.swift
@@ -2,8 +2,6 @@ import SwiftUI
 import AppKit
 import Combine
 
-// PR de prueba para issue #3 - Sistema de automatización funcionando correctamente
-
 @main
 struct MagicMouseBatteryApp: App {
     @StateObject private var batteryService = BatteryService.shared
@@ -24,10 +22,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     var eventMonitor: Any?
 
     private var batteryService: BatteryService { BatteryService.shared }
-    private var notificationService: NotificationService { NotificationService() }
+    private var notificationService: NotificationService!
     private var launchAtLoginService: LaunchAtLoginService { LaunchAtLoginService() }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Initialize notification service and connect to battery service
+        notificationService = NotificationService()
+        batteryService.notificationService = notificationService
+        
         setupStatusItem()
         setupPopover()
         setupEventMonitor()

--- a/MagicMouseBattery/Services/BatteryService.swift
+++ b/MagicMouseBattery/Services/BatteryService.swift
@@ -11,6 +11,9 @@ class BatteryService: ObservableObject {
 
     private var timer: Timer?
     var onDevicesUpdated: (() -> Void)?
+    
+    // Reference to NotificationService for sending low battery alerts
+    var notificationService: NotificationService?
 
     init() {
         refresh()
@@ -35,6 +38,9 @@ class BatteryService: ObservableObject {
                 self?.devices = detectedDevices
                 self?.lastUpdate = Date()
                 self?.onDevicesUpdated?()
+                
+                // Check battery levels and send notifications if needed
+                self?.notificationService?.checkBatteryLevels(for: detectedDevices)
             }
         }
     }


### PR DESCRIPTION
## Summary

Connect the NotificationService to BatteryService so low battery notifications actually work.

## Changes

- Add `notificationService` property to BatteryService
- Call `checkBatteryLevels()` when devices are updated
- Initialize NotificationService in AppDelegate and connect to BatteryService
- Remove test comment from MagicMouseBatteryApp.swift

## Testing

Notifications should now fire when battery falls below the configured threshold.

Fixes #8