### PR TITLE
fix: weak reference + IOKit error logging (code review)

### DIFF
--- a/MagicMouseBattery/Services/BatteryService.swift
+++ b/MagicMouseBattery/Services/BatteryService.swift
@@ -25,6 +25,8 @@ class BatteryService: ObservableObject {
         timer?.invalidate()
     }
 
+    private let monitoringInterval: TimeInterval = 60
+    
     func startMonitoring(interval: TimeInterval = 60) {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
@@ -35,13 +37,14 @@ class BatteryService: ObservableObject {
     func refresh() {
         DispatchQueue.global(qos: .background).async { [weak self] in
             let detectedDevices = self?.detectDevices() ?? []
-            DispatchQueue.main.async {
-                self?.devices = detectedDevices
-                self?.lastUpdate = Date()
-                self?.onDevicesUpdated?()
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.devices = detectedDevices
+                self.lastUpdate = Date()
+                self.onDevicesUpdated?()
                 
                 // Check battery levels and send notifications if needed
-                self?.notificationService?.checkBatteryLevels(for: detectedDevices)
+                self.notificationService?.checkBatteryLevels(for: detectedDevices)
             }
         }
     }
@@ -92,7 +95,10 @@ class BatteryService: ObservableObject {
             return nil
         }
 
-        return batteryDict as? Int
+        guard let batteryInt = batteryDict as? Int else {
+            return nil
+        }
+        return batteryInt
     }
 
     private func getProductName(from object: io_object_t) -> String? {

--- a/MagicMouseBattery/Services/BatteryService.swift
+++ b/MagicMouseBattery/Services/BatteryService.swift
@@ -13,7 +13,8 @@ class BatteryService: ObservableObject {
     var onDevicesUpdated: (() -> Void)?
     
     // Reference to NotificationService for sending low battery alerts
-    var notificationService: NotificationService?
+    // Using weak to avoid retain cycle since BatteryService is a singleton
+    weak var notificationService: NotificationService?
 
     init() {
         refresh()
@@ -54,6 +55,7 @@ class BatteryService: ObservableObject {
         let result = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDict, &iterator)
 
         guard result == KERN_SUCCESS else {
+            print("[BatteryService] IOKit: Failed to get matching services, error: \(result)")
             return devices
         }
 


### PR DESCRIPTION
## Summary

Code review fixes from DeepSeek/Nvidia API analysis:

### Changes
1. **Weak reference** - Changed  to  to avoid retain cycle (BatteryService is a singleton)
2. **IOKit error logging** - Added error logging when  fails

### Issues fixed
- Potential memory leak (retain cycle between singleton BatteryService and NotificationService)
- Missing error handling for IOKit calls

### Review summary
Issues also found in  (race condition, missing macOS <13 fallback) — can be addressed in follow-up PR if desired.

---
Reviewed with: DeepSeek V4 via Nvidia AI Foundation Models API + nvidia-ollama-proxy